### PR TITLE
Handle DB persistence in CreateTodo

### DIFF
--- a/backend/handlers/todo_handler.go
+++ b/backend/handlers/todo_handler.go
@@ -40,6 +40,10 @@ func CreateTodo(c *gin.Context) {
 		return
 	}
 	t := models.Todo{Title: body.Title}
+	if err := db.Conn.Create(&t).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "DB_ERROR", "details": err.Error()})
+		return
+	}
 	c.JSON(http.StatusCreated, t)
 }
 


### PR DESCRIPTION
## Summary
- persist new todos using the Gorm connection before responding so IDs/timestamps are included
- return a 500 response with error details if the insert fails

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ce60724e048326ac1cc268c6d01a72