### PR TITLE
Add recovery middleware to Gin router

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -31,6 +31,7 @@ func main() {
 	db.Connect(&models.Todo{})
 
 	r := gin.New()
+	r.Use(gin.Recovery())
 	r.Use(func(c *gin.Context) {
 		start := time.Now()
 		c.Next()


### PR DESCRIPTION
## Summary
- add the Gin recovery middleware right after router initialization to ensure panics return 500 responses

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1386a4f908326b1b20df1ab3a6a46